### PR TITLE
Fix typo on database schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,7 +12,7 @@ datasource db {
 
 model Contact {
   id          String @id @unique @default(uuid())
-  fistName    String
+  firstName    String
   lastName    String
   email       String @unique
   phoneNumber String @unique


### PR DESCRIPTION
**Description**
Corrigi o nome do atributo `firstName` em schema.prisma. Tava escrito `fistName`.
